### PR TITLE
Update syntax parse session

### DIFF
--- a/docs/internal/syntax-parse-update.md
+++ b/docs/internal/syntax-parse-update.md
@@ -1,0 +1,83 @@
+# fff-lang Internal Document
+
+## Syntax parser update 2
+
+syntax parser implementations have been completely updated in 23a366a, but there still remains something like,
+
+```rust
+sess.tk, sess.next_pos;
+if let &Token::Sep(sep) = sess.tk { ... sess.move_next(); ... }
+```
+
+still kind of not clear and easy, new update concerns:
+
+Update: add sess.prev_span and cut off relavant codes
+
+Analyze: parse sess interface update requirements
+    binary_expr:
+        current: `match (sess.tk, sess.pos) { (&Token::Sep(sep), sep_span) if sep.is_category($cat) => ..., ... }`
+        expect:  `match sess.try_expect_sep_cat($cat) { Some((sep, span)) => ..., None => ... }`
+    expr_lit:
+        current: `let (expect_end_sep, span) = match (sess.tk, sess.pos) { (&LBrace, span) => (RBrace, span), (&LParen, span) => (RParen, span), ... };`
+        expect:  `let (starting_sep, starting_span) = sess.expect_seps(&[LParen, LBracke, LBrace])?; let expect_end_sep = match starting_sep ...`
+    expr_list:
+        current: `if sess.tk == &expect_end_sep { ... }`
+        expect:  `if let Some((_, span)) = sess.try_expect_sep(expect_end_sep) { ... }`
+    expr_list:
+        current: `if let &Comma = sess.tk { if sess.next_tk == &expect_end_sep { sess.move_next2(); return ... } }`
+        expect:  `if let Some((_span1, ending_span)) = sess.try_expect_sep_2(Comma, expect_end_sep);`
+
+gather requirements:
+        `try_expect_sep_2`        + 2
+        `try_expect_sep`          + more than 5
+        `try_expect_sep_cat`      + 2
+        `expect_seps`             + 1
+        `try_expect_if_grammar`   + 5: primary, postfix, expr, statement, item
+    and more precise `expect xxx, yyy, zzz` message content specifier
+
+and how to update `sess.tk, sess.pos (sess.span), sess.next_tk, sess.next_span`
+    solution 1: `sess.current_token, sess.current_span, sess.next_token, sess.nextnext_span`
+    solution 2: `sess.tokens[0].token, sess.tokens[2].span`
+    soltuion 3: `sess.tokens(0).token, sess.tokens(1).span`
+    solution 4: `sess[0].token, sess[1].span`
+    solution 5: `sess.offset(0).token, sess.offset(2).span`
+    solution 6: `sess.next_nth_token(1), sess.next_nth_span(0)`
+    solution 7: `sess.token, sess.span, sess.next_token, sess.next_span, sess.nextnext_token, sess.nextnext_span`
+
+decide them after the previous features updated
+
+collect new expectations:
+
+```rust
+// old
+fn expect_sep(&mut self, sep: Seperator) -> Result<Span, ()>;
+fn expect_keyword(&mut self, kw: Keyword) -> Result<Span, ()>;
+fn expect_ident(&mut self) -> Result<(SymbolID, Span), ()>;
+fn expect_ident_or(&mut self, kws: impl Iterator<Item = Keyword>) -> Result<(SymbolID, Span), ()>;  // used by fn, for and var decl to allow underscore and this
+fn expect_ident_or_if(&mut self, f: fn(&Keyword) -> bool) -> Result<(SymbolID, Span), ()>;          // used by type use to allow primitive types
+
+// new
+fn expect_seps(&mut self, seps: impl Iterator<Item = Seperator>) -> Result<Span, ()>;               // used by expr_list to allow mutliple open seps
+fn try_expect_sep(&mut self, sep: Seperator) -> Option<Span>;                                       // used by many expecting comma, colon, paren, etc.
+fn try_expect_sep_cat(&mut self, cat: SeperatorCategory) -> Option<(Seperator, Span)>;              // used by binary and unary to filter seps
+fn try_expect_sep_2(&mut self, sep1: Seperator, sep2: Seperator) -> Option<(Span, Span)>;           // used by many try expecting comma and close seps
+fn try_expect_item_if_grammar<T: ISyntaxGrammar + ISyntaxParse>(&mut self) -> Option<T>;            // used by dispatcher like primary, postfix, expr and statements
+```
+
+ideally they will remove all `sess.tk` like and `sess.move_next()` like calls
+
+considering that later more precise expecting message information added, try aggregate them
+
+```rust
+fn expect_token(enum ExpectedToken{ Sep(Seperator), Keyword(Keyword), Seprators(Vec<Seperator>) }) -> Result<Span, ()>;
+fn expect_ident(enum ExpectedIdent{ Ident, OrKeywords(Vec<Keyword>), OrIf(fn(&Keyword) -> bool) }) -> Result<(SymbolID, Span), ()>;
+fn expect_item<T: ...>();
+fn try_expect_sep( ... );
+fn try_expect_sep_cat( ... );
+fn try_expect_sep_2(...);
+fn try_expect_item<T: ...>();
+```
+
+this seems not good
+
+starting implement new expectors

--- a/docs/name-module.md
+++ b/docs/name-module.md
@@ -97,3 +97,4 @@ from m3.m4 import M34Type;
 it works fine
 
 check [this tutorial](https://www.haskell.org/tutorial/modules.html) for information about haskell
+also consider learning about COM's design

--- a/syntax/src/expr/array_def.rs
+++ b/syntax/src/expr/array_def.rs
@@ -18,8 +18,8 @@ use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::error_strings;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemParse;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxParse;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ArrayDef {
@@ -41,11 +41,11 @@ impl From<ArrayDef> for Expr {
 impl ArrayDef {
     pub fn new(bracket_span: Span, items: ExprList) -> ArrayDef { ArrayDef{ bracket_span, items: items } }
 }
-impl ISyntaxItemGrammar for ArrayDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBracket) }
+impl ISyntaxGrammar for ArrayDef {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::LeftBracket) }
 }
-impl ISyntaxItemParse for ArrayDef {
-    type Target = Expr;
+impl ISyntaxParse for ArrayDef {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         

--- a/syntax/src/expr/array_def.rs
+++ b/syntax/src/expr/array_def.rs
@@ -42,7 +42,7 @@ impl ArrayDef {
     pub fn new(bracket_span: Span, items: ExprList) -> ArrayDef { ArrayDef{ bracket_span, items: items } }
 }
 impl ISyntaxItemGrammar for ArrayDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::LeftBracket) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBracket) }
 }
 impl ISyntaxItemParse for ArrayDef {
     type Target = Expr;

--- a/syntax/src/expr/binary_expr.rs
+++ b/syntax/src/expr/binary_expr.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 
 use codemap::Span;
-use lexical::Token;
 use lexical::Seperator;
 use lexical::SeperatorCategory;
 
@@ -82,15 +81,12 @@ impl ISyntaxItemParse for BinaryExpr {
 
                     let mut current_retval = $previous_parser(sess)?;
                     loop {
-                        match (sess.tk, sess.pos) {
-                            (&Token::Sep(operator), operator_strpos) if operator.is_category($op_category) => {
-                                sess.move_next();
+                        match sess.try_expect_sep_cat($op_category) {
+                            Some((sep, sep_span)) => {
                                 let right_expr = $previous_parser(sess)?;
-                                current_retval = Expr::Binary(BinaryExpr::new(current_retval, operator, operator_strpos, right_expr));
-                                trace!("    changing current ret_val to {:?}", current_retval);
+                                current_retval = Expr::Binary(BinaryExpr::new(current_retval, sep, sep_span, right_expr));
                             }
-                            _ => {
-                                trace!("   operator or other not '{}', return left: {:?}", stringify!($op_category), current_ret_val);
+                            None => {
                                 return Ok(current_retval);
                             }
                         }

--- a/syntax/src/expr/binary_expr.rs
+++ b/syntax/src/expr/binary_expr.rs
@@ -25,7 +25,7 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct BinaryExpr {
@@ -63,8 +63,8 @@ impl BinaryExpr {
         }
     }
 }
-impl ISyntaxItemParse for BinaryExpr {
-    type Target = Expr;
+impl ISyntaxParse for BinaryExpr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {  
         #[cfg(feature = "trace_binary_expr_parse")]

--- a/syntax/src/expr/expr_list.rs
+++ b/syntax/src/expr/expr_list.rs
@@ -15,8 +15,8 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemParse;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxParse;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ExprList {
@@ -33,12 +33,10 @@ impl fmt::Debug for ExprList {
 impl ExprList {
     pub fn new(items: Vec<Expr>) -> ExprList { ExprList{ items } }
 }
-impl ISyntaxItemGrammar for ExprList {
-    fn is_first_final(sess: &ParseSession) -> bool {
-        match sess.current_tokens()[0] {
-            &Token::Sep(Seperator::LeftBrace)
-            | &Token::Sep(Seperator::LeftBracket) 
-            | &Token::Sep(Seperator::LeftParenthenes) => true,
+impl ISyntaxGrammar for ExprList {
+    fn matches_first(tokens: &[&Token]) -> bool {
+        match tokens[0] {
+            &Token::Sep(Seperator::LeftBrace) | &Token::Sep(Seperator::LeftBracket) | &Token::Sep(Seperator::LeftParenthenes) => true,
             _ => false,
         }
     }
@@ -51,8 +49,8 @@ pub enum ExprListParseResult {
     Normal(Span, ExprList),         // and quote span
     EndWithComma(Span, ExprList),   // and quote span
 }
-impl ISyntaxItemParse for ExprList {
-    type Target = ExprListParseResult;
+impl ISyntaxParse for ExprList {
+    type Output = ExprListParseResult;
 
     /// This is special, when calling `parse`, `sess.tk` should point to the quote token
     /// Then the parser will check end token to determine end of parsing process

--- a/syntax/src/expr/expr_list.rs
+++ b/syntax/src/expr/expr_list.rs
@@ -35,7 +35,7 @@ impl ExprList {
 }
 impl ISyntaxItemGrammar for ExprList {
     fn is_first_final(sess: &ParseSession) -> bool {
-        match sess.tk {
+        match sess.current_tokens()[0] {
             &Token::Sep(Seperator::LeftBrace)
             | &Token::Sep(Seperator::LeftBracket) 
             | &Token::Sep(Seperator::LeftParenthenes) => true,

--- a/syntax/src/expr/fn_call.rs
+++ b/syntax/src/expr/fn_call.rs
@@ -18,9 +18,9 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::error_strings;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct FnCallExpr {
@@ -63,11 +63,11 @@ impl FnCallExpr {
         }
     }
 }
-impl ISyntaxItemGrammar for FnCallExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftParenthenes) }
+impl ISyntaxGrammar for FnCallExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::LeftParenthenes) }
 }
-impl ISyntaxItemParse for FnCallExpr {
-    type Target = FnCallExpr;
+impl ISyntaxParse for FnCallExpr {
+    type Output = FnCallExpr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<FnCallExpr> {
 

--- a/syntax/src/expr/fn_call.rs
+++ b/syntax/src/expr/fn_call.rs
@@ -64,7 +64,7 @@ impl FnCallExpr {
     }
 }
 impl ISyntaxItemGrammar for FnCallExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::LeftParenthenes) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftParenthenes) }
 }
 impl ISyntaxItemParse for FnCallExpr {
     type Target = FnCallExpr;

--- a/syntax/src/expr/index_call.rs
+++ b/syntax/src/expr/index_call.rs
@@ -66,7 +66,7 @@ impl IndexCallExpr {
     }
 }
 impl ISyntaxItemGrammar for IndexCallExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::LeftBracket) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBracket) }
 }
 impl ISyntaxItemParse for IndexCallExpr {
     type Target = IndexCallExpr;

--- a/syntax/src/expr/index_call.rs
+++ b/syntax/src/expr/index_call.rs
@@ -19,9 +19,9 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::error_strings;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct IndexCallExpr {
@@ -65,11 +65,11 @@ impl IndexCallExpr {
         }
     }
 }
-impl ISyntaxItemGrammar for IndexCallExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBracket) }
+impl ISyntaxGrammar for IndexCallExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::LeftBracket) }
 }
-impl ISyntaxItemParse for IndexCallExpr {
-    type Target = IndexCallExpr;
+impl ISyntaxParse for IndexCallExpr {
+    type Output = IndexCallExpr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<IndexCallExpr> {
 

--- a/syntax/src/expr/lit_expr.rs
+++ b/syntax/src/expr/lit_expr.rs
@@ -47,11 +47,7 @@ impl ISyntaxItemParse for LitExpr {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         
-        if let (&Token::Lit(ref lit_val), ref lit_val_span) = (sess.tk, sess.pos) {
-            sess.move_next();
-            Ok(Expr::Lit(LitExpr::new(*lit_val, *lit_val_span)))
-        } else {
-            sess.push_unexpect("literal")
-        }
+        let (lit, lit_span) = sess.expect_lit()?;
+        Ok(Expr::Lit(LitExpr::new(lit, lit_span)))
     }
 }

--- a/syntax/src/expr/lit_expr.rs
+++ b/syntax/src/expr/lit_expr.rs
@@ -14,9 +14,9 @@ use super::Expr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct LitExpr {
@@ -39,11 +39,11 @@ impl From<LitExpr> for Expr {
 impl LitExpr {
     pub fn new(value: LitValue, span: Span) -> LitExpr { LitExpr{ value, span } }
 }
-impl ISyntaxItemGrammar for LitExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Lit(_) = sess.current_tokens()[0] { true } else { false } }
+impl ISyntaxGrammar for LitExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { if let &Token::Lit(_) = tokens[0] { true } else { false } }
 }
-impl ISyntaxItemParse for LitExpr {
-    type Target = Expr;
+impl ISyntaxParse for LitExpr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         

--- a/syntax/src/expr/lit_expr.rs
+++ b/syntax/src/expr/lit_expr.rs
@@ -40,7 +40,7 @@ impl LitExpr {
     pub fn new(value: LitValue, span: Span) -> LitExpr { LitExpr{ value, span } }
 }
 impl ISyntaxItemGrammar for LitExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Lit(_) = sess.tk { true } else { false } }
+    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Lit(_) = sess.current_tokens()[0] { true } else { false } }
 }
 impl ISyntaxItemParse for LitExpr {
     type Target = Expr;

--- a/syntax/src/expr/member_access.rs
+++ b/syntax/src/expr/member_access.rs
@@ -15,9 +15,9 @@ use super::SimpleName;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct MemberAccessExpr {
@@ -59,11 +59,11 @@ impl MemberAccessExpr {
         }
     }
 }
-impl ISyntaxItemGrammar for MemberAccessExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::Dot) }
+impl ISyntaxGrammar for MemberAccessExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::Dot) }
 }
-impl ISyntaxItemParse for MemberAccessExpr {
-    type Target = MemberAccessExpr;
+impl ISyntaxParse for MemberAccessExpr {
+    type Output = MemberAccessExpr;
 
     // these 3 postfix exprs are kind of different because
     // although their structure contains their base expr (which actually is primary expr)

--- a/syntax/src/expr/member_access.rs
+++ b/syntax/src/expr/member_access.rs
@@ -60,7 +60,7 @@ impl MemberAccessExpr {
     }
 }
 impl ISyntaxItemGrammar for MemberAccessExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::Dot) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::Dot) }
 }
 impl ISyntaxItemParse for MemberAccessExpr {
     type Target = MemberAccessExpr;

--- a/syntax/src/expr/mod.rs
+++ b/syntax/src/expr/mod.rs
@@ -45,9 +45,9 @@ pub use self::name::Name;
 use super::Formatter;
 use super::ParseResult;
 use super::ParseSession;
-use super::ISyntaxItemParse;
+use super::ISyntaxParse;
 use super::ISyntaxFormat;
-use super::ISyntaxItemGrammar;
+use super::ISyntaxGrammar;
 
 // 12 byte
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -124,21 +124,21 @@ impl Expr {
         temp
     }
 }
-impl ISyntaxItemGrammar for Expr {
-    fn is_first_final(sess: &ParseSession) -> bool { 
-        LitExpr::is_first_final(sess)
-        || Name::is_first_final(sess)
-        || TupleDef::is_first_final(sess)
-        || ArrayDef::is_first_final(sess)
-        || UnaryExpr::is_first_final(sess) 
-        || RangeFullExpr::is_first_final(sess)
-        || sess.current_tokens()[0] == &Token::Keyword(Keyword::This)
-        // || PostfixExpr::is_first_final(sess) // same as Expr
-        // || BinaryExpr::is_first_final(sess)  // same as Expr
+impl ISyntaxGrammar for Expr {
+    fn matches_first(tokens: &[&Token]) -> bool { 
+        LitExpr::matches_first(tokens)
+        || Name::matches_first(tokens)
+        || TupleDef::matches_first(tokens)
+        || ArrayDef::matches_first(tokens)
+        || UnaryExpr::matches_first(tokens) 
+        || RangeFullExpr::matches_first(tokens)
+        || tokens[0] == &Token::Keyword(Keyword::This)
+        // || PostfixExpr::matches_first(sess) // same as Expr
+        // || BinaryExpr::matches_first(sess)  // same as Expr
     }
 }
-impl ISyntaxItemParse for Expr {
-    type Target = Expr;
+impl ISyntaxParse for Expr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         return RangeLeftExpr::parse(sess);
@@ -462,10 +462,3 @@ fn expr_unbox() {
         Expr::SimpleName(SimpleName::new(make_id!(42), make_span!(30, 31)))
     }
 }
-
-// TODO: range expr
-// maybe:
-// updates: expr = ... | range_full | range_left_unbound | range_right_unbound | range_both_bound
-// struct RangeLeftUnbound, as primary_expr, is_first_final => tk == Range, parse => '..' [ unary_expr ]
-// struct RangeLeftBound as postfix_expr, is_first_final => tk == Range, parse => [ expr ] '..' [ expr ], left expr is handled by 
-// check python and rust and haskell's design

--- a/syntax/src/expr/mod.rs
+++ b/syntax/src/expr/mod.rs
@@ -132,7 +132,7 @@ impl ISyntaxItemGrammar for Expr {
         || ArrayDef::is_first_final(sess)
         || UnaryExpr::is_first_final(sess) 
         || RangeFullExpr::is_first_final(sess)
-        || sess.tk == &Token::Keyword(Keyword::This)
+        || sess.current_tokens()[0] == &Token::Keyword(Keyword::This)
         // || PostfixExpr::is_first_final(sess) // same as Expr
         // || BinaryExpr::is_first_final(sess)  // same as Expr
     }

--- a/syntax/src/expr/name.rs
+++ b/syntax/src/expr/name.rs
@@ -85,13 +85,13 @@ impl ISyntaxItemParse for Name {
         if let &Token::Sep(Seperator::NamespaceSeperator) = sess.tk {
             let mut segments = vec![first_segment]; 
             loop {
-                if let &Token::Sep(Seperator::NamespaceSeperator) = sess.tk {
-                    sess.move_next();
-                    let segment = SimpleName::parse(sess)?;
-                    all_span = all_span.merge(&segment.span);
-                    segments.push(segment);
-                } else {
-                    break;
+                match sess.try_expect_sep(Seperator::NamespaceSeperator) {
+                    Some(_double_colon_span) => {
+                        let segment = SimpleName::parse(sess)?;
+                        all_span = all_span.merge(&segment.span);
+                        segments.push(segment);
+                    }
+                    None => break,
                 }
             }
             Ok(Expr::Name(Name::new(all_span, segments)))

--- a/syntax/src/expr/name.rs
+++ b/syntax/src/expr/name.rs
@@ -79,24 +79,24 @@ impl ISyntaxItemParse for Name {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         
-        let mut all_span = sess.pos;
         let first_segment = SimpleName::parse(sess)?;
-
-        if let &Token::Sep(Seperator::NamespaceSeperator) = sess.tk {
-            let mut segments = vec![first_segment]; 
-            loop {
-                match sess.try_expect_sep(Seperator::NamespaceSeperator) {
-                    Some(_double_colon_span) => {
-                        let segment = SimpleName::parse(sess)?;
-                        all_span = all_span.merge(&segment.span);
-                        segments.push(segment);
-                    }
-                    None => break,
-                }
+        let mut all_span = first_segment.span;
+        let mut segments = vec![first_segment];
+        
+        loop {
+            if let Some(_) = sess.try_expect_sep(Seperator::NamespaceSeperator) {
+                let segment = SimpleName::parse(sess)?;
+                all_span = all_span.merge(&segment.span);
+                segments.push(segment);
+            } else {
+                break;
             }
+        }
+        
+        if segments.len() > 1 {
             Ok(Expr::Name(Name::new(all_span, segments)))
         } else {
-            Ok(Expr::SimpleName(first_segment))
+            Ok(Expr::SimpleName(segments.pop().unwrap()))
         }
     }
 }

--- a/syntax/src/expr/name.rs
+++ b/syntax/src/expr/name.rs
@@ -72,7 +72,7 @@ impl Name {
     pub fn new(all_span: Span, segments: Vec<SimpleName>) -> Name { Name{ all_span, segments } }
 }
 impl ISyntaxItemGrammar for Name {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Ident(_) = sess.tk { true } else { false } }
+    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Ident(_) = sess.current_tokens()[0] { true } else { false } }
 }
 impl ISyntaxItemParse for Name {
     type Target = Expr;

--- a/syntax/src/expr/name.rs
+++ b/syntax/src/expr/name.rs
@@ -16,9 +16,9 @@ use super::Expr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct SimpleName {
@@ -39,8 +39,8 @@ impl From<SimpleName> for Expr {
 impl SimpleName {
     pub fn new(value: SymbolID, span: Span) -> SimpleName { SimpleName{ value, span } }
 }
-impl ISyntaxItemParse for SimpleName {
-    type Target = SimpleName; // out of expr depdendencies require direct parse and get a simple name
+impl ISyntaxParse for SimpleName {
+    type Output = SimpleName; // out of expr depdendencies require direct parse and get a simple name
 
     fn parse(sess: &mut ParseSession) -> ParseResult<SimpleName> {
         let (value, span) = sess.expect_ident()?;
@@ -71,11 +71,11 @@ impl From<Name> for Expr {
 impl Name {
     pub fn new(all_span: Span, segments: Vec<SimpleName>) -> Name { Name{ all_span, segments } }
 }
-impl ISyntaxItemGrammar for Name {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Ident(_) = sess.current_tokens()[0] { true } else { false } }
+impl ISyntaxGrammar for Name {
+    fn matches_first(tokens: &[&Token]) -> bool { if let &Token::Ident(_) = tokens[0] { true } else { false } }
 }
-impl ISyntaxItemParse for Name {
-    type Target = Expr;
+impl ISyntaxParse for Name {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         

--- a/syntax/src/expr/priority_proxy.rs
+++ b/syntax/src/expr/priority_proxy.rs
@@ -32,7 +32,7 @@ impl ISyntaxItemParse for PrimaryExpr {
         #[cfg(not(feature = "trace_primary_expr_parse"))]
         macro_rules! trace { ($($arg:tt)*) => () }
 
-        trace!("start parsing, current token: {:?}", sess.tk);
+        trace!("start parsing, current token: {:?}", sess.current_tokens()[0]);
 
         if LitExpr::is_first_final(sess) {
             return LitExpr::parse(sess);

--- a/syntax/src/expr/priority_proxy.rs
+++ b/syntax/src/expr/priority_proxy.rs
@@ -19,28 +19,22 @@ use super::MemberAccessExpr;
 
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxParse;
+use super::super::ISyntaxGrammar;
 
 pub struct PrimaryExpr;
-impl ISyntaxItemParse for PrimaryExpr {
-    type Target = Expr;
+impl ISyntaxParse for PrimaryExpr {
+    type Output = Expr;
     
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
-        #[cfg(feature = "trace_primary_expr_parse")]
-        macro_rules! trace { ($($arg:tt)*) => ({ print!("[PrimaryExpr: {}]", line!()); println!($($arg)*); }) }
-        #[cfg(not(feature = "trace_primary_expr_parse"))]
-        macro_rules! trace { ($($arg:tt)*) => () }
 
-        trace!("start parsing, current token: {:?}", sess.current_tokens()[0]);
-
-        if LitExpr::is_first_final(sess) {
+        if LitExpr::matches_first(sess.current_tokens()) {
             return LitExpr::parse(sess);
-        } else if Name::is_first_final(sess) {
+        } else if Name::matches_first(sess.current_tokens()) {
             return Name::parse(sess);
-        } else if TupleDef::is_first_final(sess) {
+        } else if TupleDef::matches_first(sess.current_tokens()) {
             return TupleDef::parse(sess);
-        } else if ArrayDef::is_first_final(sess) {
+        } else if ArrayDef::matches_first(sess.current_tokens()) {
             return ArrayDef::parse(sess);
         }
 
@@ -50,8 +44,8 @@ impl ISyntaxItemParse for PrimaryExpr {
 }
 
 pub struct PostfixExpr;
-impl ISyntaxItemParse for PostfixExpr {
-    type Target = Expr;
+impl ISyntaxParse for PostfixExpr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {   
         #[cfg(feature = "trace_postfix_expr_parse")]
@@ -63,17 +57,17 @@ impl ISyntaxItemParse for PostfixExpr {
         trace!("parsed primary, current is {:?}", current_retval);
 
         loop {
-            if MemberAccessExpr::is_first_final(sess) {
+            if MemberAccessExpr::matches_first(sess.current_tokens()) {
                 let mut postfix = MemberAccessExpr::parse(sess)?;
                 postfix.all_span = current_retval.get_all_span().merge(&postfix.name.span);
                 postfix.base = Box::new(current_retval);
                 current_retval = Expr::MemberAccess(postfix);
-            } else if FnCallExpr::is_first_final(sess) {
+            } else if FnCallExpr::matches_first(sess.current_tokens()) {
                 let mut postfix = FnCallExpr::parse(sess)?;
                 postfix.all_span = current_retval.get_all_span().merge(&postfix.paren_span);
                 postfix.base = Box::new(current_retval);
                 current_retval = Expr::FnCall(postfix);
-            } else if IndexCallExpr::is_first_final(sess) {
+            } else if IndexCallExpr::matches_first(sess.current_tokens()) {
                 let mut postfix = IndexCallExpr::parse(sess)?;
                 postfix.all_span = current_retval.get_all_span().merge(&postfix.bracket_span);
                 postfix.base = Box::new(current_retval);

--- a/syntax/src/expr/priority_proxy.rs
+++ b/syntax/src/expr/priority_proxy.rs
@@ -5,7 +5,6 @@
 ///! primary_expr = ident_expr | lit_expr | unit_lit | paren_expr | tuple_def | array_def
 ///! postfix_expr = expr { ( member_access | fn_call | indexer_call ) }
 
-use lexical::Token;
 use lexical::Keyword;
 
 use super::Expr;
@@ -45,12 +44,8 @@ impl ISyntaxItemParse for PrimaryExpr {
             return ArrayDef::parse(sess);
         }
 
-        if let (&Token::Keyword(Keyword::This), this_span) = (sess.tk, sess.pos) {
-            sess.move_next();
-            return Ok(Expr::SimpleName(SimpleName::new(sess.symbols.intern_str("this"), this_span)));
-        } else {
-            return sess.push_unexpect("primary expr");
-        }
+        let (this_id, this_span) = sess.expect_ident_or(vec![Keyword::This])?;  // actually identifier is processed by Name, not here
+        return Ok(Expr::SimpleName(SimpleName::new(this_id, this_span)));
     }
 }
 

--- a/syntax/src/expr/range_expr.rs
+++ b/syntax/src/expr/range_expr.rs
@@ -63,7 +63,7 @@ impl RangeRightExpr {
 }
 
 impl ISyntaxItemGrammar for RangeFullExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::Range) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::Range) }
 }
 impl ISyntaxItemParse for RangeFullExpr {
     type Target = Expr;
@@ -140,8 +140,7 @@ impl ISyntaxItemParse for RangeLeftExpr {
     
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         let left_expr = BinaryExpr::parse(sess)?;
-        if sess.tk == &Token::Sep(Seperator::Range) {
-            let op_span = sess.expect_sep(Seperator::Range)?;
+        if let Some(op_span) = sess.try_expect_sep(Seperator::Range) {
             if Expr::is_first_final(sess) {
                 let right_expr = BinaryExpr::parse(sess)?;
                 return Ok(Expr::RangeBoth(RangeBothExpr::new(left_expr, op_span, right_expr)));

--- a/syntax/src/expr/range_expr.rs
+++ b/syntax/src/expr/range_expr.rs
@@ -15,9 +15,9 @@ use super::BinaryExpr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct RangeFullExpr {
@@ -62,15 +62,15 @@ impl RangeRightExpr {
     }
 }
 
-impl ISyntaxItemGrammar for RangeFullExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::Range) }
+impl ISyntaxGrammar for RangeFullExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::Range) }
 }
-impl ISyntaxItemParse for RangeFullExpr {
-    type Target = Expr;
+impl ISyntaxParse for RangeFullExpr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         let span = sess.expect_sep(Seperator::Range)?;
-        if Expr::is_first_final(sess) {
+        if Expr::matches_first(sess.current_tokens()) {
             let expr = BinaryExpr::parse(sess)?;
             return Ok(Expr::RangeRight(RangeRightExpr::new(span.merge(&expr.get_all_span()), expr)));
         }
@@ -135,13 +135,13 @@ impl RangeBothExpr {
     }
 }
 
-impl ISyntaxItemParse for RangeLeftExpr {
-    type Target = Expr;
+impl ISyntaxParse for RangeLeftExpr {
+    type Output = Expr;
     
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         let left_expr = BinaryExpr::parse(sess)?;
         if let Some(op_span) = sess.try_expect_sep(Seperator::Range) {
-            if Expr::is_first_final(sess) {
+            if Expr::matches_first(sess.current_tokens()) {
                 let right_expr = BinaryExpr::parse(sess)?;
                 return Ok(Expr::RangeBoth(RangeBothExpr::new(left_expr, op_span, right_expr)));
             } else {

--- a/syntax/src/expr/tuple_def.rs
+++ b/syntax/src/expr/tuple_def.rs
@@ -75,7 +75,7 @@ impl TupleDef {
     pub fn new(paren_span: Span, items: ExprList) -> TupleDef { TupleDef{ paren_span, items } }
 }
 impl ISyntaxItemGrammar for TupleDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::LeftParenthenes) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftParenthenes) }
 }
 impl ISyntaxItemParse for TupleDef {
     type Target = Expr;

--- a/syntax/src/expr/tuple_def.rs
+++ b/syntax/src/expr/tuple_def.rs
@@ -23,9 +23,9 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::error_strings;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 // Paren expr is a side effect of TupleDef
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -74,11 +74,11 @@ impl From<TupleDef> for Expr {
 impl TupleDef {
     pub fn new(paren_span: Span, items: ExprList) -> TupleDef { TupleDef{ paren_span, items } }
 }
-impl ISyntaxItemGrammar for TupleDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftParenthenes) }
+impl ISyntaxGrammar for TupleDef {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::LeftParenthenes) }
 }
-impl ISyntaxItemParse for TupleDef {
-    type Target = Expr;
+impl ISyntaxParse for TupleDef {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
 

--- a/syntax/src/expr/tuple_def.rs
+++ b/syntax/src/expr/tuple_def.rs
@@ -91,7 +91,7 @@ impl ISyntaxItemParse for TupleDef {
                 return Ok(Expr::Tuple(TupleDef::new(span, ExprList::new(Vec::new()))));
             }
             ExprListParseResult::Normal(span, exprlist) => {
-                if Vec::len(&exprlist.items) == 1 {
+                if exprlist.items.len() == 1 {
                     return Ok(Expr::Paren(ParenExpr::new(span, exprlist.items.into_iter().last().unwrap())));
                 } else {
                     return Ok(Expr::Tuple(TupleDef::new(span, exprlist)));

--- a/syntax/src/expr/unary_expr.rs
+++ b/syntax/src/expr/unary_expr.rs
@@ -16,9 +16,9 @@ use super::PostfixExpr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct UnaryExpr {
@@ -52,16 +52,16 @@ impl UnaryExpr {
         }
     }
 }
-impl ISyntaxItemGrammar for UnaryExpr {
-    fn is_first_final(sess: &ParseSession) -> bool { 
-        match sess.current_tokens()[0] {
+impl ISyntaxGrammar for UnaryExpr {
+    fn matches_first(tokens: &[&Token]) -> bool { 
+        match tokens[0] {
             &Token::Sep(ref sep) if sep.is_category(SeperatorCategory::Unary) => true,
             _ => false,
         }
     }
 }
-impl ISyntaxItemParse for UnaryExpr {
-    type Target = Expr;
+impl ISyntaxParse for UnaryExpr {
+    type Output = Expr;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Expr> {
         

--- a/syntax/src/expr/unary_expr.rs
+++ b/syntax/src/expr/unary_expr.rs
@@ -67,12 +67,9 @@ impl ISyntaxItemParse for UnaryExpr {
         
         let mut op_spans = Vec::new();
         loop {
-            match (sess.tk, sess.pos) {
-                (&Token::Sep(operator), operator_strpos) if operator.is_category(SeperatorCategory::Unary) => {
-                    sess.move_next();
-                    op_spans.push((operator, operator_strpos));
-                }
-                _ => {
+            match sess.try_expect_sep_cat(SeperatorCategory::Unary) {
+                Some((sep, sep_span)) => op_spans.push((sep, sep_span)),
+                None => {
                     let base = PostfixExpr::parse(sess)?;
                     return Ok(op_spans.into_iter().rev().fold(base, |base, (op, span)| { Expr::Unary(UnaryExpr::new(op, span, base)) }));
                 }

--- a/syntax/src/expr/unary_expr.rs
+++ b/syntax/src/expr/unary_expr.rs
@@ -54,7 +54,7 @@ impl UnaryExpr {
 }
 impl ISyntaxItemGrammar for UnaryExpr {
     fn is_first_final(sess: &ParseSession) -> bool { 
-        match sess.tk {
+        match sess.current_tokens()[0] {
             &Token::Sep(ref sep) if sep.is_category(SeperatorCategory::Unary) => true,
             _ => false,
         }

--- a/syntax/src/items/block.rs
+++ b/syntax/src/items/block.rs
@@ -48,14 +48,13 @@ impl ISyntaxItemParse for Block {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Block> {
 
-        let starting_strpos = sess.expect_sep(Seperator::LeftBrace)?;
+        let starting_span = sess.expect_sep(Seperator::LeftBrace)?;
         let mut items = Vec::new();
         loop {
-            if let (&Token::Sep(Seperator::RightBrace), ref right_brace_strpos) = (sess.tk, sess.pos) {
-                sess.move_next();
-                return Ok(Block::new(starting_strpos.merge(right_brace_strpos), items));
+            if let Some(ending_span) = sess.try_expect_sep(Seperator::RightBrace) {
+                return Ok(Block::new(starting_span.merge(&ending_span), items));
             }
-            items.push(Statement::parse(sess)?); 
+            items.push(Statement::parse(sess)?);
         }
     }
 }

--- a/syntax/src/items/block.rs
+++ b/syntax/src/items/block.rs
@@ -13,9 +13,9 @@ use super::super::Statement;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Block {
@@ -40,11 +40,11 @@ impl Block {
 
     pub fn new(all_span: Span, statements: Vec<Statement>) -> Block { Block{ all_span, items: statements } }
 }
-impl ISyntaxItemGrammar for Block {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBrace) }
+impl ISyntaxGrammar for Block {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Sep(Seperator::LeftBrace) }
 }
-impl ISyntaxItemParse for Block {
-    type Target = Block;
+impl ISyntaxParse for Block {
+    type Output = Block;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Block> {
 

--- a/syntax/src/items/block.rs
+++ b/syntax/src/items/block.rs
@@ -41,7 +41,7 @@ impl Block {
     pub fn new(all_span: Span, statements: Vec<Statement>) -> Block { Block{ all_span, items: statements } }
 }
 impl ISyntaxItemGrammar for Block {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Sep(Seperator::LeftBrace) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Sep(Seperator::LeftBrace) }
 }
 impl ISyntaxItemParse for Block {
     type Target = Block;

--- a/syntax/src/items/fn_def.rs
+++ b/syntax/src/items/fn_def.rs
@@ -73,7 +73,7 @@ impl FnDef {
     }
 }
 impl ISyntaxItemGrammar for FnDef {   
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Fn) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Fn) }
 }
 impl ISyntaxItemParse for FnDef {
     type Target = FnDef;

--- a/syntax/src/items/fn_def.rs
+++ b/syntax/src/items/fn_def.rs
@@ -17,9 +17,9 @@ use super::super::TypeUse;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct FnParam {
@@ -72,11 +72,11 @@ impl FnDef {
         FnDef{ name, name_span, params, params_paren_span, ret_type, body, all_span }
     }
 }
-impl ISyntaxItemGrammar for FnDef {   
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Fn) }
+impl ISyntaxGrammar for FnDef {   
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Fn) }
 }
-impl ISyntaxItemParse for FnDef {
-    type Target = FnDef;
+impl ISyntaxParse for FnDef {
+    type Output = FnDef;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<FnDef> {
         #[cfg(feature = "trace_fn_def_parse")]

--- a/syntax/src/items/label_def.rs
+++ b/syntax/src/items/label_def.rs
@@ -36,7 +36,7 @@ impl LabelDef {
     pub fn new(name: SymbolID, all_span: Span) -> LabelDef { LabelDef{ name, all_span } }
 }
 impl ISyntaxItemGrammar for LabelDef {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Label(_) = sess.tk { true } else { false } }
+    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Label(_) = sess.current_tokens()[0] { true } else { false } }
 }
 impl ISyntaxItemParse for LabelDef {
     type Target = LabelDef;

--- a/syntax/src/items/label_def.rs
+++ b/syntax/src/items/label_def.rs
@@ -43,14 +43,11 @@ impl ISyntaxItemParse for LabelDef {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<LabelDef> {
 
-        match (sess.tk, sess.pos, sess.next_tk, sess.next_pos) {
-            (&Token::Label(ref label_name), ref label_name_strpos,
-                &Token::Sep(Seperator::Colon), ref colon_strpos) => {
-                sess.move_next2();
-                Ok(LabelDef::new(label_name.clone(), label_name_strpos.merge(colon_strpos)))
-            }
-            (&Token::Label(_), _, _, _) => sess.push_unexpect("colon"),
-            _ => sess.push_unexpect("label"),
+        if let Some((label_id, label_span)) = sess.try_expect_label() {
+            let colon_span = sess.expect_sep(Seperator::Colon)?;
+            Ok(LabelDef::new(label_id, label_span.merge(&colon_span)))
+        } else {
+            sess.push_unexpect("label")
         }
     }
 }

--- a/syntax/src/items/label_def.rs
+++ b/syntax/src/items/label_def.rs
@@ -14,9 +14,9 @@ use lexical::Seperator;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct LabelDef {
@@ -35,11 +35,11 @@ impl LabelDef {
     
     pub fn new(name: SymbolID, all_span: Span) -> LabelDef { LabelDef{ name, all_span } }
 }
-impl ISyntaxItemGrammar for LabelDef {
-    fn is_first_final(sess: &ParseSession) -> bool { if let &Token::Label(_) = sess.current_tokens()[0] { true } else { false } }
+impl ISyntaxGrammar for LabelDef {
+    fn matches_first(tokens: &[&Token]) -> bool { if let &Token::Label(_) = tokens[0] { true } else { false } }
 }
-impl ISyntaxItemParse for LabelDef {
-    type Target = LabelDef;
+impl ISyntaxParse for LabelDef {
+    type Output = LabelDef;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<LabelDef> {
 

--- a/syntax/src/items/module.rs
+++ b/syntax/src/items/module.rs
@@ -11,9 +11,9 @@ use super::super::Item;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Module {
@@ -34,13 +34,13 @@ impl fmt::Debug for Module {
 impl Module {
     pub fn new(items: Vec<Item>) -> Module { Module{ items } }
 }
-impl ISyntaxItemParse for Module {
-    type Target = Module;
+impl ISyntaxParse for Module {
+    type Output = Module;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Module> {
         let mut items = Vec::new();
         loop {
-            if Item::is_first_final(sess) {
+            if Item::matches_first(sess.current_tokens()) {
                 items.push(Item::parse(sess)?);
             } else if sess.current_tokens()[0] == &Token::EOF { // as module is special, specially allow self.current_tokens in parse
                 break;

--- a/syntax/src/items/module.rs
+++ b/syntax/src/items/module.rs
@@ -42,7 +42,7 @@ impl ISyntaxItemParse for Module {
         loop {
             if Item::is_first_final(sess) {
                 items.push(Item::parse(sess)?);
-            } else if sess.tk == &Token::EOF {
+            } else if sess.current_tokens()[0] == &Token::EOF { // as module is special, specially allow self.current_tokens in parse
                 break;
             } else {
                 return sess.push_unexpect("if, while, for, var, const, expr");

--- a/syntax/src/items/type_def.rs
+++ b/syntax/src/items/type_def.rs
@@ -20,9 +20,9 @@ use super::super::SimpleName;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct TypeFieldDef {
@@ -63,11 +63,11 @@ impl TypeDef {
         TypeDef{ all_span, name, fields }
     }
 }
-impl ISyntaxItemGrammar for TypeDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Type) }
+impl ISyntaxGrammar for TypeDef {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Type) }
 }
-impl ISyntaxItemParse for TypeDef {
-    type Target = Self;
+impl ISyntaxParse for TypeDef {
+    type Output = Self;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<TypeDef> {
 

--- a/syntax/src/items/type_def.rs
+++ b/syntax/src/items/type_def.rs
@@ -64,7 +64,7 @@ impl TypeDef {
     }
 }
 impl ISyntaxItemGrammar for TypeDef {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Type) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Type) }
 }
 impl ISyntaxItemParse for TypeDef {
     type Target = Self;

--- a/syntax/src/items/type_use.rs
+++ b/syntax/src/items/type_use.rs
@@ -71,7 +71,7 @@ impl TypeUse {
 }
 impl ISyntaxItemGrammar for TypeUse {
     fn is_first_final(sess: &ParseSession) -> bool {
-        match sess.tk {
+        match sess.current_tokens()[0] {
             &Token::Ident(_) 
             | &Token::Sep(Seperator::LeftBracket)
             | &Token::Sep(Seperator::LeftParenthenes) => true,

--- a/syntax/src/items/type_use.rs
+++ b/syntax/src/items/type_use.rs
@@ -31,9 +31,9 @@ use lexical::Keyword;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct TypeUse {
@@ -69,9 +69,9 @@ impl TypeUse {
         TypeUse{ all_span: base_span.merge(&quote_span), base, base_span, quote_span, params }
     }
 }
-impl ISyntaxItemGrammar for TypeUse {
-    fn is_first_final(sess: &ParseSession) -> bool {
-        match sess.current_tokens()[0] {
+impl ISyntaxGrammar for TypeUse {
+    fn matches_first(tokens: &[&Token]) -> bool {
+        match tokens[0] {
             &Token::Ident(_) 
             | &Token::Sep(Seperator::LeftBracket)
             | &Token::Sep(Seperator::LeftParenthenes) => true,
@@ -80,8 +80,8 @@ impl ISyntaxItemGrammar for TypeUse {
         }
     }
 }
-impl ISyntaxItemParse for TypeUse {
-    type Target = TypeUse;
+impl ISyntaxParse for TypeUse {
+    type Output = TypeUse;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<TypeUse> {
 

--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -8,11 +8,11 @@
 extern crate lexical;
 
 #[macro_use] mod expr;
+mod parse_sess;
 mod items;
 mod statement;
 mod error_strings;
 mod format_helper;
-mod parse_sess;
 mod syntax_tree;
 mod test_helper;
 

--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -63,8 +63,8 @@ pub use self::syntax_tree::SyntaxTree;
 
 use self::parse_sess::ParseSession;
 use self::parse_sess::ParseResult;
-use self::parse_sess::ISyntaxItemGrammar;
-pub use self::parse_sess::ISyntaxItemParse; // pub for semantic/traits
+use self::parse_sess::ISyntaxGrammar;
+pub use self::parse_sess::ISyntaxParse;
 
 use self::format_helper::Formatter;
 use self::format_helper::ISyntaxFormat;

--- a/syntax/src/parse_sess.rs
+++ b/syntax/src/parse_sess.rs
@@ -15,7 +15,6 @@ use lexical::LitValue;
 
 pub type ParseResult<T> = Result<T, ()>;
 
-#[allow(dead_code)]
 pub struct ParseSession<'tokens, 'msgs, 'syms> {
     tokens: &'tokens TokenStream,
     messages: &'msgs mut MessageCollection,
@@ -23,7 +22,7 @@ pub struct ParseSession<'tokens, 'msgs, 'syms> {
     current_index: usize,
     current_tokens: [&'tokens Token; 3],
 }
-#[allow(dead_code)]
+#[allow(dead_code)] // helper methods may not be used
 impl<'a, 'b, 'c> ParseSession<'a, 'b, 'c> {
 
     pub fn new(tokens: &'a TokenStream, messages: &'b mut MessageCollection, symbols: &'c mut SymbolCollection) -> ParseSession<'a, 'b, 'c> {
@@ -292,17 +291,17 @@ impl<'a, 'b, 'c> ParseSession<'a, 'b, 'c> {
     }
 }
 
-pub trait ISyntaxItemGrammar {
-    fn is_first_final(sess: &ParseSession) -> bool;
+pub trait ISyntaxGrammar {
+    fn matches_first(tokens: &[&Token]) -> bool;
 }
-pub trait ISyntaxItemParse {
-    type Target;
+pub trait ISyntaxParse {
+    type Output;
     
-    fn parse(sess: &mut ParseSession) -> ParseResult<Self::Target>;
+    fn parse(sess: &mut ParseSession) -> ParseResult<Self::Output>;
 
     // check is_first_final, if pass, parse, return Ok(Some(T)) or Err(()), else return None
-    fn try_parse(sess: &mut ParseSession) -> ParseResult<Option<Self::Target>> where Self: ISyntaxItemGrammar {
-        if Self::is_first_final(sess) { Ok(Some(Self::parse(sess)?)) } else { Ok(None) }
+    fn try_parse(sess: &mut ParseSession) -> ParseResult<Option<Self::Output>> where Self: ISyntaxGrammar {
+        if Self::matches_first(sess.current_tokens()) { Ok(Some(Self::parse(sess)?)) } else { Ok(None) }
     }
 }
 

--- a/syntax/src/parse_sess.rs
+++ b/syntax/src/parse_sess.rs
@@ -305,5 +305,4 @@ pub trait ISyntaxParse {
     }
 }
 
-// TODO: update ISyntaxItemGrammar to ISyntaxGrammar { fn matches_first(tokens: &[&Token]) -> bool; /* maybe */ fn follows() -> String; }
-// update ISyntaxItemParse to ISyntaxParse { type Output; fn parse, fn try_parse }
+// TODO: consider better unexpected descriptions

--- a/syntax/src/parse_sess.rs
+++ b/syntax/src/parse_sess.rs
@@ -136,6 +136,21 @@ impl<'a, 'b, 'c> ParseSession<'a, 'b, 'c> {
         }
     }
 
+    /// Check current token is a label
+    /// 
+    /// if so, move next and Some((symid, sym_span)), 
+    /// if not, no move next and None
+    ///
+    /// example `if let Some((symid, label_span)) = sess.try_expect_label() { ... }`
+    pub fn try_expect_label(&mut self) -> Option<(SymbolID, Span)> {
+        
+        let current_index = self.current_index.get();
+        match (self.tokens.nth_token(current_index), self.tokens.nth_span(current_index)) {
+            (&Token::Label(ref id), ref label_span) => { self.move_next(); Some((*id, *label_span)) },
+            _ => None,
+        }
+    }
+
     /// Check current token is identifier or acceptable keywords
     /// 
     /// if so, move next and Ok((symbol_id, ident_span)),
@@ -190,6 +205,21 @@ impl<'a, 'b, 'c> ParseSession<'a, 'b, 'c> {
             _ => None,
         }
     }
+
+    /// Check current token is specified keyword
+    ///
+    /// if so, move next and Some(kw_span), 
+    /// if not, no move next and None
+    ///
+    /// example `if let Some(kw_span) == sess.try_expect_keyword(Keyword::If) { ... }`
+    pub fn try_expect_keyword(&mut self, expected_keyword: Keyword) -> Option<Span> {
+
+        let current_index = self.current_index.get();
+        match (self.tokens.nth_token(current_index), self.tokens.nth_span(current_index)) {
+            (&Token::Keyword(ref actual_kw), ref kw_span) if actual_kw == &expected_keyword => { self.move_next(); Some(*kw_span) },
+            _ => None,
+        }
+    }
     
     /// Check current and next token is specified seperators
     ///
@@ -204,6 +234,21 @@ impl<'a, 'b, 'c> ParseSession<'a, 'b, 'c> {
             self.tokens.nth_token(current_index + 1), self.tokens.nth_span(current_index + 1)) {
             (&Token::Sep(ref sep1), sep1_span, &Token::Sep(ref sep2), sep2_span) 
                 if sep1 == &expected_sep1 && sep2 == &expected_sep2 => { self.move_next2(); Some((sep1_span, sep2_span)) },
+            _ => None,
+        }
+    }
+
+    /// Check current token is of seperator category
+    ///
+    /// if so, move next and Some((sep, sep_span)), 
+    /// if not, no move next and None
+    ///
+    /// example `if let Some((sep, sep_span)) = sess.try_expect_sep_cat(Unary) { ... }`
+    pub fn try_expect_sep_cat(&mut self, expected_cat: u16) -> Option<(Seperator, Span)> {
+
+        let current_index = self.current_index.get();
+        match (self.tokens.nth_token(current_index), self.tokens.nth_span(current_index)) {
+            (&Token::Sep(ref sep), ref sep_span) if sep.is_category(expected_cat) => { self.move_next(); Some((*sep, *sep_span)) },
             _ => None,
         }
     }

--- a/syntax/src/statement/block_stmt.rs
+++ b/syntax/src/statement/block_stmt.rs
@@ -51,7 +51,7 @@ impl BlockStatement {
 }
 impl ISyntaxItemGrammar for BlockStatement {
     fn is_first_final(sess: &ParseSession) -> bool { 
-        match (sess.tk, sess.nextnext_tk) {
+        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
             (&Token::Label(_), &Token::Sep(Seperator::LeftBrace)) 
             | (&Token::Sep(Seperator::LeftBrace), _) => true,
             _ => false,

--- a/syntax/src/statement/block_stmt.rs
+++ b/syntax/src/statement/block_stmt.rs
@@ -15,9 +15,9 @@ use super::super::LabelDef;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct BlockStatement {
@@ -49,17 +49,17 @@ impl BlockStatement {
         } 
     }
 }
-impl ISyntaxItemGrammar for BlockStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { 
-        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
+impl ISyntaxGrammar for BlockStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { 
+        match (tokens[0], tokens[2]) {
             (&Token::Label(_), &Token::Sep(Seperator::LeftBrace)) 
             | (&Token::Sep(Seperator::LeftBrace), _) => true,
             _ => false,
         }
     }
 }
-impl ISyntaxItemParse for BlockStatement {
-    type Target = BlockStatement;
+impl ISyntaxParse for BlockStatement {
+    type Output = BlockStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<BlockStatement> {
     

--- a/syntax/src/statement/expr_stmt.rs
+++ b/syntax/src/statement/expr_stmt.rs
@@ -88,8 +88,8 @@ impl ISyntaxItemParse for AssignExprStatement {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Statement> {
 
-        let starting_span = sess.pos;
         let left_expr = Expr::parse(sess)?;
+        let starting_span = left_expr.get_all_span();
 
         if let Some(semicolon_span) = sess.try_expect_sep(Seperator::SemiColon) {
             Ok(Statement::SimpleExpr(SimpleExprStatement::new(starting_span.merge(&semicolon_span), left_expr)))

--- a/syntax/src/statement/expr_stmt.rs
+++ b/syntax/src/statement/expr_stmt.rs
@@ -6,6 +6,7 @@
 use std::fmt;
 
 use codemap::Span;
+use lexical::Token;
 use lexical::Seperator;
 use lexical::SeperatorCategory;
 
@@ -14,9 +15,9 @@ use super::super::Expr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct SimpleExprStatement {
@@ -39,12 +40,12 @@ impl SimpleExprStatement {
     }
 }
 // dispatch them to convenience statement define macro
-impl ISyntaxItemGrammar for SimpleExprStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { AssignExprStatement::is_first_final(sess) }
+impl ISyntaxGrammar for SimpleExprStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { AssignExprStatement::matches_first(tokens) }
 }
-impl ISyntaxItemParse for SimpleExprStatement {
-    type Target = <AssignExprStatement as ISyntaxItemParse>::Target;
-    fn parse(sess: &mut ParseSession) -> ParseResult<Self::Target> { AssignExprStatement::parse(sess) }
+impl ISyntaxParse for SimpleExprStatement {
+    type Output = <AssignExprStatement as ISyntaxParse>::Output;
+    fn parse(sess: &mut ParseSession) -> ParseResult<Self::Output> { AssignExprStatement::parse(sess) }
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -80,11 +81,11 @@ impl AssignExprStatement {
     }
 }
 
-impl ISyntaxItemGrammar for AssignExprStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { Expr::is_first_final(sess) }
+impl ISyntaxGrammar for AssignExprStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { Expr::matches_first(tokens) }
 }
-impl ISyntaxItemParse for AssignExprStatement {
-    type Target = Statement;
+impl ISyntaxParse for AssignExprStatement {
+    type Output = Statement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<Statement> {
 

--- a/syntax/src/statement/for_stmt.rs
+++ b/syntax/src/statement/for_stmt.rs
@@ -88,7 +88,7 @@ impl ForStatement {
 impl ISyntaxItemGrammar for ForStatement {
 
     fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.tk, sess.nextnext_tk) {
+        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::For)) | (&Token::Keyword(Keyword::For), _) => true,
             _ => false
         }

--- a/syntax/src/statement/for_stmt.rs
+++ b/syntax/src/statement/for_stmt.rs
@@ -18,9 +18,9 @@ use super::super::LabelDef;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ForStatement {
@@ -85,17 +85,16 @@ impl ForStatement {
         }
     }
 }
-impl ISyntaxItemGrammar for ForStatement {
-
-    fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
+impl ISyntaxGrammar for ForStatement {
+    fn matches_first(tokens: &[&Token]) -> bool {
+        match (tokens[0], tokens[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::For)) | (&Token::Keyword(Keyword::For), _) => true,
             _ => false
         }
     }
 }
-impl ISyntaxItemParse for ForStatement {
-    type Target = ForStatement;
+impl ISyntaxParse for ForStatement {
+    type Output = ForStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<ForStatement> {
 

--- a/syntax/src/statement/for_stmt.rs
+++ b/syntax/src/statement/for_stmt.rs
@@ -101,10 +101,7 @@ impl ISyntaxItemParse for ForStatement {
 
         let maybe_label = LabelDef::try_parse(sess)?;
         let for_strpos = sess.expect_keyword(Keyword::For)?;
-
-        // Accept _ as iter_name, _ do not declare iter var
-        let (iter_name, iter_strpos) = sess.expect_ident_or(vec![Keyword::Underscore])?;
-
+        let (iter_name, iter_strpos) = sess.expect_ident_or(vec![Keyword::Underscore])?; // Accept _ as iter_name, _ do not declare iter var
         let _in_strpos = sess.expect_keyword(Keyword::In)?;
         let iter_expr = Expr::parse(sess)?;
         let body = Block::parse(sess)?;

--- a/syntax/src/statement/if_stmt.rs
+++ b/syntax/src/statement/if_stmt.rs
@@ -14,9 +14,9 @@ use super::super::Block;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct IfClause {
@@ -140,11 +140,11 @@ impl IfStatement {
         }
     }
 }
-impl ISyntaxItemGrammar for IfStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::If) }
+impl ISyntaxGrammar for IfStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::If) }
 }
-impl ISyntaxItemParse for IfStatement {
-    type Target = IfStatement;
+impl ISyntaxParse for IfStatement {
+    type Output = IfStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<IfStatement> {
 

--- a/syntax/src/statement/if_stmt.rs
+++ b/syntax/src/statement/if_stmt.rs
@@ -159,24 +159,23 @@ impl ISyntaxItemParse for IfStatement {
         let mut elseif_clauses = Vec::new();
         let mut else_clause = None;
         loop {
-            match (sess.tk, sess.pos, sess.next_tk, sess.next_pos) {
-                (&Token::Keyword(Keyword::Else), ref else_span, &Token::Keyword(Keyword::If), ref if_span) => {
-                    sess.move_next2();
+            if let Some(else_span) = sess.try_expect_keyword(Keyword::Else) {
+                if let Some(if_span) = sess.try_expect_keyword(Keyword::If) {
                     let elseif_span = else_span.merge(&if_span);
                     let elseif_expr = Expr::parse(sess)?;
                     let elseif_body = Block::parse(sess)?;
                     elseif_clauses.push(ElseIfClause::new(elseif_span, elseif_expr, elseif_body));
-                }
-                (&Token::Keyword(Keyword::Else), ref else_span, _, _) => {
-                    sess.move_next();
+                } else {
                     // 16/12/1, we lost TWO `+1`s for current_length here ... fixed
                     // 17/5/6: When there is match Block::parse(tokens, messages, index + current_length), etc.
                     // There was a bug fix here, now no more current_length handling!
                     // 17/6/21: a new physical structure update makes it much more simple
+                    // 17/7/28: a new small update of parse_sess makes things even more simple
                     let else_body = Block::parse(sess)?;
-                    else_clause = Some(ElseClause::new(*else_span, else_body));
+                    else_clause = Some(ElseClause::new(else_span, else_body));
                 }
-                _ => break,
+            } else {
+                break;
             }
         }
 

--- a/syntax/src/statement/if_stmt.rs
+++ b/syntax/src/statement/if_stmt.rs
@@ -147,11 +147,8 @@ impl ISyntaxItemParse for IfStatement {
     type Target = IfStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<IfStatement> {
-        assert!(sess.tk == &Token::Keyword(Keyword::If));
 
-        let if_span = sess.pos;
-        sess.move_next();
-        
+        let if_span = sess.expect_keyword(Keyword::If)?;
         let if_expr = Expr::parse(sess)?;
         let if_body = Block::parse(sess)?;
         let if_clause = IfClause::new(if_span, if_expr, if_body);

--- a/syntax/src/statement/if_stmt.rs
+++ b/syntax/src/statement/if_stmt.rs
@@ -141,7 +141,7 @@ impl IfStatement {
     }
 }
 impl ISyntaxItemGrammar for IfStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::If) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::If) }
 }
 impl ISyntaxItemParse for IfStatement {
     type Target = IfStatement;

--- a/syntax/src/statement/import_stmt.rs
+++ b/syntax/src/statement/import_stmt.rs
@@ -53,7 +53,7 @@ impl ImportStatement {
     }
 }
 impl ISyntaxItemGrammar for ImportStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Import) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Import) }
 }
 impl ISyntaxItemParse for ImportStatement {
     type Target = ImportStatement;

--- a/syntax/src/statement/import_stmt.rs
+++ b/syntax/src/statement/import_stmt.rs
@@ -63,13 +63,12 @@ impl ISyntaxItemParse for ImportStatement {
         let starting_span = sess.expect_keyword(Keyword::Import)?;
         let name = SimpleName::parse(sess)?;
 
-        let (as_span, to_ident) = if let &Token::Keyword(Keyword::As) = sess.tk {
-            let as_span = sess.pos;
-            sess.move_next();
+        let (as_span, to_ident) = if let Some(as_span) = sess.try_expect_keyword(Keyword::As) {
             (as_span, Some(SimpleName::parse(sess)?))
         } else {
             (Span::default(), None)
         };
+        
         let semicolon_span = sess.expect_sep(Seperator::SemiColon)?;
         let all_span = starting_span.merge(&semicolon_span);
 

--- a/syntax/src/statement/import_stmt.rs
+++ b/syntax/src/statement/import_stmt.rs
@@ -14,9 +14,9 @@ use super::super::SimpleName;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemParse;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ImportStatement {
@@ -52,11 +52,11 @@ impl ImportStatement {
         ImportStatement{ name, all_span, as_span, target }
     }
 }
-impl ISyntaxItemGrammar for ImportStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Import) }
+impl ISyntaxGrammar for ImportStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Import) }
 }
-impl ISyntaxItemParse for ImportStatement {
-    type Target = ImportStatement;
+impl ISyntaxParse for ImportStatement {
+    type Output = ImportStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<ImportStatement> {
 

--- a/syntax/src/statement/jump_stmt.rs
+++ b/syntax/src/statement/jump_stmt.rs
@@ -15,9 +15,9 @@ use lexical::Keyword;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct JumpStatement {
@@ -89,21 +89,21 @@ impl BreakStatement {
     }
 }
 
-impl ISyntaxItemGrammar for ContinueStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Continue) }
+impl ISyntaxGrammar for ContinueStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Continue) }
 }
-impl ISyntaxItemGrammar for BreakStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Break) }
+impl ISyntaxGrammar for BreakStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Break) }
 }
 
-impl ISyntaxItemParse for ContinueStatement {
-    type Target = ContinueStatement;
+impl ISyntaxParse for ContinueStatement {
+    type Output = ContinueStatement;
     fn parse(sess: &mut ParseSession) -> ParseResult<ContinueStatement> { 
         Ok(ContinueStatement(JumpStatement::parse(sess, Keyword::Continue)?))
     }
 }
-impl ISyntaxItemParse for BreakStatement {
-    type Target = BreakStatement;
+impl ISyntaxParse for BreakStatement {
+    type Output = BreakStatement;
     fn parse(sess: &mut ParseSession) -> ParseResult<BreakStatement> {
         Ok(BreakStatement(JumpStatement::parse(sess, Keyword::Break)?))
     }

--- a/syntax/src/statement/jump_stmt.rs
+++ b/syntax/src/statement/jump_stmt.rs
@@ -90,10 +90,10 @@ impl BreakStatement {
 }
 
 impl ISyntaxItemGrammar for ContinueStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Continue) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Continue) }
 }
 impl ISyntaxItemGrammar for BreakStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Break) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Break) }
 }
 
 impl ISyntaxItemParse for ContinueStatement {

--- a/syntax/src/statement/loop_stmt.rs
+++ b/syntax/src/statement/loop_stmt.rs
@@ -15,9 +15,9 @@ use super::super::LabelDef;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct LoopStatement {
@@ -63,16 +63,16 @@ impl LoopStatement { // New
         }
     }
 }
-impl ISyntaxItemGrammar for LoopStatement {
-    fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
+impl ISyntaxGrammar for LoopStatement {
+    fn matches_first(tokens: &[&Token]) -> bool {
+        match (tokens[0], tokens[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::Loop)) | (&Token::Keyword(Keyword::Loop), _) => true,
             _ => false
         }
     }
 }
-impl ISyntaxItemParse for LoopStatement {
-    type Target = LoopStatement;
+impl ISyntaxParse for LoopStatement {
+    type Output = LoopStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<LoopStatement> {
 

--- a/syntax/src/statement/loop_stmt.rs
+++ b/syntax/src/statement/loop_stmt.rs
@@ -65,7 +65,7 @@ impl LoopStatement { // New
 }
 impl ISyntaxItemGrammar for LoopStatement {
     fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.tk, sess.nextnext_tk) {
+        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::Loop)) | (&Token::Keyword(Keyword::Loop), _) => true,
             _ => false
         }

--- a/syntax/src/statement/ret_stmt.rs
+++ b/syntax/src/statement/ret_stmt.rs
@@ -14,9 +14,9 @@ use super::super::Expr;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ReturnStatement {
@@ -45,11 +45,11 @@ impl ReturnStatement {
         ReturnStatement{ all_span, expr: Some(expr) }
     }
 }
-impl ISyntaxItemGrammar for ReturnStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Return) }
+impl ISyntaxGrammar for ReturnStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Return) }
 }
-impl ISyntaxItemParse for ReturnStatement {
-    type Target = ReturnStatement;
+impl ISyntaxParse for ReturnStatement {
+    type Output = ReturnStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<ReturnStatement> {
 

--- a/syntax/src/statement/ret_stmt.rs
+++ b/syntax/src/statement/ret_stmt.rs
@@ -46,7 +46,7 @@ impl ReturnStatement {
     }
 }
 impl ISyntaxItemGrammar for ReturnStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Return) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Return) }
 }
 impl ISyntaxItemParse for ReturnStatement {
     type Target = ReturnStatement;

--- a/syntax/src/statement/use_stmt.rs
+++ b/syntax/src/statement/use_stmt.rs
@@ -65,9 +65,7 @@ impl ISyntaxItemParse for UseStatement {
         let starting_span = sess.expect_keyword(Keyword::Use)?;
         let from_name = Name::parse(sess)?.into_name();
 
-        let (as_span, to_ident) = if let &Token::Keyword(Keyword::As) = sess.tk {
-            let as_span = sess.pos;
-            sess.move_next();
+        let (as_span, to_ident) = if let Some(as_span) = sess.try_expect_keyword(Keyword::As) {
             (as_span, Some(SimpleName::parse(sess)?))
         } else {
             (Span::default(), None)

--- a/syntax/src/statement/use_stmt.rs
+++ b/syntax/src/statement/use_stmt.rs
@@ -16,8 +16,8 @@ use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemParse;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxParse;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct UseStatement {
@@ -54,11 +54,11 @@ impl UseStatement {
         UseStatement{ name, all_span, as_span, target }
     }
 }
-impl ISyntaxItemGrammar for UseStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Use) }
+impl ISyntaxGrammar for UseStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Use) }
 }
-impl ISyntaxItemParse for UseStatement {
-    type Target = UseStatement;
+impl ISyntaxParse for UseStatement {
+    type Output = UseStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<UseStatement> {
 

--- a/syntax/src/statement/use_stmt.rs
+++ b/syntax/src/statement/use_stmt.rs
@@ -55,7 +55,7 @@ impl UseStatement {
     }
 }
 impl ISyntaxItemGrammar for UseStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Use) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Use) }
 }
 impl ISyntaxItemParse for UseStatement {
     type Target = UseStatement;

--- a/syntax/src/statement/var_decl.rs
+++ b/syntax/src/statement/var_decl.rs
@@ -68,7 +68,7 @@ impl VarDeclStatement {
     }
 }
 impl ISyntaxItemGrammar for VarDeclStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.tk == &Token::Keyword(Keyword::Const) || sess.tk == &Token::Keyword(Keyword::Var) }
+    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Const) || sess.current_tokens()[0] == &Token::Keyword(Keyword::Var) }
 }
 impl ISyntaxItemParse for VarDeclStatement {
     type Target = VarDeclStatement;

--- a/syntax/src/statement/var_decl.rs
+++ b/syntax/src/statement/var_decl.rs
@@ -18,9 +18,9 @@ use super::super::TypeUse;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct VarDeclStatement {
@@ -67,11 +67,11 @@ impl VarDeclStatement {
         VarDeclStatement{ all_span, is_const: false, name, name_span, typeuse, init_expr }
     }
 }
-impl ISyntaxItemGrammar for VarDeclStatement {
-    fn is_first_final(sess: &ParseSession) -> bool { sess.current_tokens()[0] == &Token::Keyword(Keyword::Const) || sess.current_tokens()[0] == &Token::Keyword(Keyword::Var) }
+impl ISyntaxGrammar for VarDeclStatement {
+    fn matches_first(tokens: &[&Token]) -> bool { tokens[0] == &Token::Keyword(Keyword::Const) || tokens[0] == &Token::Keyword(Keyword::Var) }
 }
-impl ISyntaxItemParse for VarDeclStatement {
-    type Target = VarDeclStatement;
+impl ISyntaxParse for VarDeclStatement {
+    type Output = VarDeclStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<VarDeclStatement> {
         

--- a/syntax/src/statement/var_decl.rs
+++ b/syntax/src/statement/var_decl.rs
@@ -75,6 +75,7 @@ impl ISyntaxItemParse for VarDeclStatement {
 
     fn parse(sess: &mut ParseSession) -> ParseResult<VarDeclStatement> {
         
+        // let (starting_kw, starting_span) = sess.expect_keywords
         let starting_strpos = sess.pos;
         let is_const = match sess.tk {
             &Token::Keyword(Keyword::Const) => true, 

--- a/syntax/src/statement/while_stmt.rs
+++ b/syntax/src/statement/while_stmt.rs
@@ -16,9 +16,9 @@ use super::super::LabelDef;
 use super::super::Formatter;
 use super::super::ParseResult;
 use super::super::ParseSession;
-use super::super::ISyntaxItemParse;
+use super::super::ISyntaxParse;
 use super::super::ISyntaxFormat;
-use super::super::ISyntaxItemGrammar;
+use super::super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct WhileStatement {
@@ -66,16 +66,16 @@ impl WhileStatement {
         }
     }
 }
-impl ISyntaxItemGrammar for WhileStatement {
-    fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
+impl ISyntaxGrammar for WhileStatement {
+    fn matches_first(tokens: &[&Token]) -> bool {
+        match (tokens[0], tokens[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::While)) | (&Token::Keyword(Keyword::While), _) => true,
             _ => false
         }
     }
 }
-impl ISyntaxItemParse for WhileStatement {
-    type Target = WhileStatement;
+impl ISyntaxParse for WhileStatement {
+    type Output = WhileStatement;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<WhileStatement> {
         

--- a/syntax/src/statement/while_stmt.rs
+++ b/syntax/src/statement/while_stmt.rs
@@ -68,7 +68,7 @@ impl WhileStatement {
 }
 impl ISyntaxItemGrammar for WhileStatement {
     fn is_first_final(sess: &ParseSession) -> bool {
-        match (sess.tk, sess.nextnext_tk) {
+        match (sess.current_tokens()[0], sess.current_tokens()[2]) {
             (&Token::Label(_), &Token::Keyword(Keyword::While)) | (&Token::Keyword(Keyword::While), _) => true,
             _ => false
         }

--- a/syntax/src/syntax_tree.rs
+++ b/syntax/src/syntax_tree.rs
@@ -45,7 +45,7 @@ impl ISyntaxItemParse for SyntaxTree {
         loop {
             if Item::is_first_final(sess) {
                 items.push(Item::parse(sess)?);
-            } else if sess.tk == &Token::EOF {
+            } else if sess.current_tokens()[0] == &Token::EOF {
                 break;
             } else {
                 return sess.push_unexpect("if, while, for, var, const, expr");

--- a/syntax/src/syntax_tree.rs
+++ b/syntax/src/syntax_tree.rs
@@ -14,9 +14,9 @@ use super::Item;
 use super::Formatter;
 use super::ParseResult;
 use super::ParseSession;
-use super::ISyntaxItemParse;
+use super::ISyntaxParse;
 use super::ISyntaxFormat;
-use super::ISyntaxItemGrammar;
+use super::ISyntaxGrammar;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct SyntaxTree {
@@ -37,13 +37,13 @@ impl fmt::Debug for SyntaxTree {
 impl SyntaxTree {
     pub fn new_items(items: Vec<Item>) -> SyntaxTree { SyntaxTree{ items } }
 }
-impl ISyntaxItemParse for SyntaxTree {
-    type Target = SyntaxTree;
+impl ISyntaxParse for SyntaxTree {
+    type Output = SyntaxTree;
 
     fn parse(sess: &mut ParseSession) -> ParseResult<SyntaxTree> {
         let mut items = Vec::new();
         loop {
-            if Item::is_first_final(sess) {
+            if Item::matches_first(sess.current_tokens()) {
                 items.push(Item::parse(sess)?);
             } else if sess.current_tokens()[0] == &Token::EOF {
                 break;

--- a/syntax/src/test_helper.rs
+++ b/syntax/src/test_helper.rs
@@ -10,7 +10,7 @@ use message::MessageCollection;
 use lexical::TokenStream;
 
 use super::ParseSession;
-use super::ISyntaxItemParse;
+use super::ISyntaxParse;
 
 pub trait WithTestInput {
     type Output: Sized;
@@ -83,7 +83,7 @@ impl<T> TestInputResult<T> {
     pub fn finish(self) { }
 }
 
-impl<T, U> WithTestInput for T where T: ISyntaxItemParse<Target = U> {
+impl<T, U> WithTestInput for T where T: ISyntaxParse<Output = U> {
     type Output = U;
 
     fn with_test_input(input: TestInput) -> (Option<U>, SourceCode, MessageCollection, SymbolCollection) {


### PR DESCRIPTION
updates:

- more parse session helper methods, include `try_expect_*` methods
- remove legacy `[next][next]_tk` and `[next][next]_pos` fields
- move current index out of cell
- make `move_next[2]` private and then current token index management is completely removed from outside of parse session
- rename `ISyntaxItem*` to `ISyntax*`
- change `is_first_final(sess)` to `matches_first(tokens)`