### PR TITLE
Add multiple file support in semantic

### DIFF
--- a/semantic/src/analyze_helper.rs
+++ b/semantic/src/analyze_helper.rs
@@ -2,9 +2,118 @@
 ///!
 ///! semantic/traits
 
+use std::fmt;
+
+use codemap::Span;
+use codemap::SymbolID;
+use codemap::SourceCode;
+use codemap::SymbolCollection;
+
 use super::SharedDefScope;
 
+const INDENTION_FILLERS: [[&str; 16]; 3] = [ [
+    "", "1 ", "2 | ", "3 | | ", "4 | | | ", "5 | | | | ", "6 | | | | | ", "7 | | | | | | ", "8 | | | | | | | ", "9 | | | | | | | | ", "10 | | | | | | | | | ",
+    "11| | | | | | | | | | ", "12| | | | | | | | | | | ", "13| | | | | | | | | | | | ", "14| | | | | | | | | | | | | ", "15| | | | | | | | | | | | "
+], [
+    "", "| ", "| | ", "| | | ", "| | | | ", "| | | | | ", "| | | | | | ", "| | | | | | | ", "| | | | | | | | ", "| | | | | | | | | ", "| | | | | | | | | | ",
+    "| | | | | | | | | | | ", "| | | | | | | | | | | | ", "| | | | | | | | | | | | | ", "| | | | | | | | | | | | | | ", "| | | | | | | | | | | | | "
+], [
+    "", "  ", "    ", "      ", "        ", "          ", "            ", "              ", "                ", "                  ", "                    ",
+    "                      ", "                        ", "                          ", "                            ", "                          "
+]];
+const CURRENT_INDEX_INDEX: usize = 2;
+
+#[derive(Clone)]
+pub struct Formatter<'a, 'b> {
+    indent_index: usize,
+    source: Option<&'a SourceCode>,
+    symbols: Option<&'b SymbolCollection>,
+    header_text: Option<&'static str>, // lazy to add a 'c
+    prefix_text: Option<&'static str>,
+    buf: String,
+}
+impl<'a, 'b> Formatter<'a, 'b> {
+
+    pub fn new(source: Option<&'a SourceCode>, symbols: Option<&'b SymbolCollection>) -> Self {
+        Formatter{ indent_index: 0, source, symbols, header_text: None, prefix_text: None, buf: String::new() }
+    }
+    pub fn with_test_indent(indent: usize) -> Self {
+        Formatter{ indent_index: indent, source: None, symbols: None, header_text: None, prefix_text: None, buf: String::new() }
+    }
+    pub fn empty() -> Self {
+        Formatter{ indent_index: 0, source: None, symbols: None, header_text: None, prefix_text: None, buf: String::new() }
+    }
+
+    // set only once
+    pub fn set_header_text(mut self, header_text: &'static str) -> Self { self.header_text = Some(header_text); self }
+    pub fn unset_header_text(mut self) -> Self { self.header_text = None; self }
+    pub fn set_prefix_text(mut self, prefix_text: &'static str) -> Self { self.prefix_text = Some(prefix_text); self }
+    pub fn unset_prefix_text(mut self) -> Self { self.prefix_text = None; self }
+}
+impl<'a, 'b> Formatter<'a, 'b> {
+
+    pub fn lit(mut self, v: &str) -> Self { self.buf.push_str(v); self }
+    pub fn debug<T: fmt::Debug>(mut self, v: &T) -> Self { self.buf.push_str(&format!("{:?}", v)); self }
+    pub fn space(mut self) -> Self { self.buf.push(' '); self }
+    pub fn endl(mut self) -> Self { self.buf.push('\n'); self }
+
+    pub fn span(mut self, span: Span) -> Self { self.buf.push_str(&format!("{}", span.format(self.source))); self }
+    pub fn sym(mut self, id: SymbolID) -> Self { self.buf.push_str(&format!("{}", id.format(self.symbols))); self  }
+    pub fn header_text_or(mut self, v: &'static str) -> Self {
+        let need_extra_empty = self.prefix_text.is_some();
+        self.buf.push_str(self.prefix_text.unwrap_or(""));
+        self.prefix_text = None;
+        if need_extra_empty { self.buf.push(' '); }
+        self.buf.push_str(self.header_text.unwrap_or(v));
+        self.header_text = None;
+        self
+    }
+
+    pub fn indent(mut self) -> Self { self.buf.push_str(INDENTION_FILLERS[CURRENT_INDEX_INDEX][self.indent_index]); self }
+    pub fn indent1(mut self) -> Self { self.buf.push_str(INDENTION_FILLERS[CURRENT_INDEX_INDEX][self.indent_index + 1]); self }
+    pub fn indent2(mut self) -> Self { self.buf.push_str(INDENTION_FILLERS[CURRENT_INDEX_INDEX][self.indent_index + 2]); self }
+
+    pub fn apply<T: ISemanticAnalyze>(mut self, item: &T) -> Self {
+        self.buf.push_str(&item.format(Formatter{        // a manual clone because lazy to add derive(Clone)
+            indent_index: self.indent_index,
+            source: self.source, symbols: self.symbols,
+            header_text: self.header_text, prefix_text: self.prefix_text, buf: String::new(),
+        }));
+        self
+    }
+    pub fn apply1<T: ISemanticAnalyze>(mut self, item: &T) -> Self {
+        self.buf.push_str(&item.format(Formatter{        // a manual clone because lazy to add derive(Clone)
+            indent_index: self.indent_index + 1,
+            source: self.source, symbols: self.symbols,
+            header_text: self.header_text, prefix_text: self.prefix_text, buf: String::new(),
+        }));
+        self
+    }
+    pub fn apply2<T: ISemanticAnalyze>(mut self, item: &T) -> Self {
+        self.buf.push_str(&item.format(Formatter{        // a manual clone because lazy to add derive(Clone)
+            indent_index: self.indent_index + 2,
+            source: self.source, symbols: self.symbols,
+            header_text: self.header_text, prefix_text: self.prefix_text, buf: String::new(),
+        }));
+        self
+    }
+
+    pub fn finish(self) -> String { self.buf }
+}
+
+pub struct Wrapper<'a, T: 'a>(&'a T);
+impl<'a, T: ISemanticAnalyze> fmt::Display for Wrapper<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "\n{}", self.0.format(Formatter::empty()))
+    }
+}
+
 pub trait ISemanticAnalyze {
+
+    // Display, which is actually Debug but I don't like `fn debug() -> String`, should not be implemented
+    fn display<'a>(&'a self) -> Wrapper<'a, Self> where Self: Sized { Wrapper(self) }
+    // format, should be implemented
+    fn format(&self, f: Formatter) -> String { "<unknown>".to_owned() }
 
     // phase 1: direct map from syntax node
     type SyntaxItem;

--- a/semantic/src/analyze_helper.rs
+++ b/semantic/src/analyze_helper.rs
@@ -1,0 +1,15 @@
+///! fff-lang
+///!
+///! semantic/traits
+
+use super::SharedDefScope;
+
+pub trait ISemanticAnalyze {
+
+    // phase 1: direct map from syntax node
+    type SyntaxItem;
+    fn from_syntax(item: Self::SyntaxItem, parent_scope: SharedDefScope) -> Self;
+
+    // TODO: an empty implement for compatibility temporarily, remove it in future
+    fn collect_type_declarations(&mut self) { }
+}

--- a/semantic/src/def_scope.rs
+++ b/semantic/src/def_scope.rs
@@ -29,6 +29,3 @@ impl DefScope {
 
 pub type SharedDefScope = Rc<RefCell<DefScope>>;
 
-pub trait FromSyntax<T> {
-    fn from_syntax(item: T, parent_scope: SharedDefScope) -> Self;
-}

--- a/semantic/src/expr/range_expr.rs
+++ b/semantic/src/expr/range_expr.rs
@@ -1,0 +1,72 @@
+///! fff-lang
+///!
+///! semantic/range_expr, syntax/range_expr direct maps
+
+use syntax;
+
+use super::Expr;
+use super::super::SharedDefScope;
+use super::super::ISemanticAnalyze;
+
+use std::marker::PhantomData;
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+pub struct RangeFullExpr {
+    pub phantom: PhantomData<()>,
+}
+impl ISemanticAnalyze for RangeFullExpr {
+
+    type SyntaxItem = syntax::RangeFullExpr;
+
+    fn from_syntax(_node: syntax::RangeFullExpr, _parent_scope: SharedDefScope) -> RangeFullExpr {
+        RangeFullExpr{
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+pub struct RangeLeftExpr {
+    pub expr: Box<Expr>,
+}
+impl ISemanticAnalyze for RangeLeftExpr {
+
+    type SyntaxItem = syntax::RangeLeftExpr;
+
+    fn from_syntax(node: syntax::RangeLeftExpr, parent_scope: SharedDefScope) -> RangeLeftExpr {
+        RangeLeftExpr{
+            expr: Box::new(Expr::from_syntax(syntax::Expr::unbox(node.expr), parent_scope.clone())),
+        }
+    }
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+pub struct RangeRightExpr {
+    pub expr: Box<Expr>,
+}
+impl ISemanticAnalyze for RangeRightExpr {
+
+    type SyntaxItem = syntax::RangeRightExpr;
+
+    fn from_syntax(node: syntax::RangeRightExpr, parent_scope: SharedDefScope) -> RangeRightExpr {
+        RangeRightExpr{
+            expr: Box::new(Expr::from_syntax(syntax::Expr::unbox(node.expr), parent_scope.clone())),
+        }
+    }
+}
+
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
+pub struct RangeBothExpr {
+    pub left_expr: Box<Expr>,
+    pub right_expr: Box<Expr>,
+}
+impl ISemanticAnalyze for RangeBothExpr {
+
+    type SyntaxItem = syntax::RangeBothExpr;
+
+    fn from_syntax(node: syntax::RangeBothExpr, parent_scope: SharedDefScope) -> RangeBothExpr {
+        RangeBothExpr{
+            left_expr: Box::new(Expr::from_syntax(syntax::Expr::unbox(node.left_expr), parent_scope.clone())),
+            right_expr: Box::new(Expr::from_syntax(syntax::Expr::unbox(node.right_expr), parent_scope.clone())),
+        }
+    }
+}

--- a/semantic/src/items/fn_def.rs
+++ b/semantic/src/items/fn_def.rs
@@ -7,21 +7,13 @@ use syntax;
 
 use super::TypeUse;
 use super::Block;
-use super::super::FromSyntax;
+use super::super::ISemanticAnalyze;
 use super::super::SharedDefScope;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct FnParam {
     pub name: SymbolID,
     pub typeuse: TypeUse,
-}
-impl FromSyntax<syntax::FnParam> for FnParam {
-    fn from_syntax(node: syntax::FnParam, parent_scope: SharedDefScope) -> FnParam {
-        FnParam{
-            name: node.name,
-            typeuse: FromSyntax::from_syntax(node.decltype, parent_scope.clone()),
-        }
-    }
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
@@ -31,14 +23,21 @@ pub struct FnDef {
     pub rettype: Option<TypeUse>,
     pub body: Block,
 }
-impl FromSyntax<syntax::FnDef> for FnDef {
+impl ISemanticAnalyze for FnDef {
+
+    type SyntaxItem = syntax::FnDef;
 
     fn from_syntax(node: syntax::FnDef, parent_scope: SharedDefScope) -> FnDef {
         FnDef{
             name: node.name,
-            params: node.params.into_iter().map(|param| FromSyntax::from_syntax(param, parent_scope.clone())).collect(),
-            rettype: node.ret_type.map(|ty| FromSyntax::from_syntax(ty, parent_scope.clone())),
-            body: FromSyntax::from_syntax(node.body, parent_scope.clone()),
+            params: node.params.into_iter().map(|param| {
+                FnParam{
+                    name: param.name,
+                    typeuse: TypeUse::from_syntax(param.decltype, parent_scope.clone()),
+                }
+            }).collect(),
+            rettype: node.ret_type.map(|ty| TypeUse::from_syntax(ty, parent_scope.clone())),
+            body: Block::from_syntax(node.body, parent_scope.clone()),
         }
     }
 }

--- a/semantic/src/items/mod.rs
+++ b/semantic/src/items/mod.rs
@@ -16,20 +16,22 @@ pub use self::fn_def::FnDef;
 pub use self::module::Module;
 
 use super::Statement;
-use super::FromSyntax;
 use super::SharedDefScope;
+use super::ISemanticAnalyze;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct TypeUse {
     pub base_name: SymbolID,
     pub params: Vec<TypeUse>,
 }
-impl FromSyntax<syntax::TypeUse> for TypeUse {
+impl ISemanticAnalyze for TypeUse {
     
+    type SyntaxItem = syntax::TypeUse;
+
     fn from_syntax(node: syntax::TypeUse, parent_scope: SharedDefScope) -> TypeUse {
         TypeUse{
             base_name: node.base,
-            params: node.params.into_iter().map(|param| FromSyntax::from_syntax(param, parent_scope.clone())).collect(),
+            params: node.params.into_iter().map(|param| TypeUse::from_syntax(param, parent_scope.clone())).collect(),
         }
     }
 }
@@ -38,8 +40,11 @@ impl FromSyntax<syntax::TypeUse> for TypeUse {
 pub struct LabelDef {
     pub name: SymbolID,
 }
-impl FromSyntax<syntax::LabelDef> for LabelDef {
-    fn from_syntax(node: syntax::LabelDef, parent_scope: SharedDefScope) -> LabelDef {
+impl ISemanticAnalyze for LabelDef {
+
+    type SyntaxItem = syntax::LabelDef;
+
+    fn from_syntax(node: syntax::LabelDef, _parent_scope: SharedDefScope) -> LabelDef {
         LabelDef{
             name: node.name,
         }
@@ -50,10 +55,13 @@ impl FromSyntax<syntax::LabelDef> for LabelDef {
 pub struct Block {
     pub items: Vec<Statement>,
 }
-impl FromSyntax<syntax::Block> for Block {
+impl ISemanticAnalyze for Block {
+
+    type SyntaxItem = syntax::Block;
+    
     fn from_syntax(node: syntax::Block, parent_scope: SharedDefScope) -> Block {
         Block{
-            items: node.items.into_iter().map(|item| FromSyntax::from_syntax(item, parent_scope.clone())).collect(),
+            items: node.items.into_iter().map(|item| Statement::from_syntax(item, parent_scope.clone())).collect(),
         }
     }
 }

--- a/semantic/src/items/module.rs
+++ b/semantic/src/items/module.rs
@@ -12,8 +12,8 @@ use super::super::ISemanticAnalyze;
 
 #[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 pub struct Module {
+    pub module_id: usize,
     pub items: Vec<Item>,
-    pub imports: Vec<Module>,
 }
 impl ISemanticAnalyze for Module {
 
@@ -21,8 +21,31 @@ impl ISemanticAnalyze for Module {
 
     fn from_syntax(node: syntax::Module, parent_scope: SharedDefScope) -> Module {
         Module{
-            imports: Vec::new(),
+            module_id: node.source.get_file_id(),
             items: node.items.into_iter().map(|item| Item::from_syntax(item, parent_scope.clone())).collect(),
+        }
+    }
+}
+impl Module {
+
+    // phase 1 special, move content out, because it is hard to move out of vec
+    pub fn move_out(&mut self) -> Module { 
+        let mut retval = Module{ module_id: self.module_id, items: Vec::new() };
+        retval.items.append(&mut self.items);
+        return retval; 
+    }
+    pub fn buildup_imports(&mut self, import_maps: &Vec<syntax::ImportMap>, modules: &mut Vec<Module>) {
+
+        let module_id = self.module_id; // if use `self.module_id` in the for expr then rustc complains about mutably borrowed self in `&mut self.items` ... hope non lexical lifetime solve this
+        for item in &mut self.items {
+            if let &mut Item::Import(ref mut import_stmt) = item {
+                let imported_file_id = import_maps.into_iter()
+                    .filter(|import_map| import_map.file_id == module_id && import_map.import_name == import_stmt.name.value)
+                    .next().unwrap().imported_file_id;  // valid syntax tree will make sure this next and this unwrap is success
+                let mut imported_module = modules[imported_file_id].move_out();
+                imported_module.buildup_imports(import_maps, modules);
+                import_stmt.module = Some(imported_module);
+            }
         }
     }
 }

--- a/semantic/src/items/module.rs
+++ b/semantic/src/items/module.rs
@@ -7,19 +7,22 @@ use syntax;
 use codemap::SymbolID;
 
 use super::super::Item;
-use super::super::FromSyntax;
 use super::super::SharedDefScope;
+use super::super::ISemanticAnalyze;
 
 #[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 pub struct Module {
     pub items: Vec<Item>,
     pub imports: Vec<Module>,
 }
-impl FromSyntax<syntax::Module> for Module {
+impl ISemanticAnalyze for Module {
+
+    type SyntaxItem = syntax::Module;
+
     fn from_syntax(node: syntax::Module, parent_scope: SharedDefScope) -> Module {
         Module{
             imports: Vec::new(),
-            items: node.items.into_iter().map(|item| FromSyntax::from_syntax(item, parent_scope.clone())).collect(),
+            items: node.items.into_iter().map(|item| Item::from_syntax(item, parent_scope.clone())).collect(),
         }
     }
 }

--- a/semantic/src/items/type_def.rs
+++ b/semantic/src/items/type_def.rs
@@ -9,21 +9,13 @@ use codemap::SymbolID;
 use syntax;
 
 use super::TypeUse;
-use super::super::FromSyntax;
 use super::super::SharedDefScope;
+use super::super::ISemanticAnalyze;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct TypeFieldDef {
     pub name: SymbolID,
     pub typeuse: TypeUse,
-}
-impl FromSyntax<syntax::TypeFieldDef> for TypeFieldDef {
-    fn from_syntax(node: syntax::TypeFieldDef, parent_scope: SharedDefScope) -> TypeFieldDef {
-        TypeFieldDef{
-            name: node.name.value,
-            typeuse: FromSyntax::from_syntax(node.typeuse, parent_scope.clone()),
-        }
-    }
 }
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
@@ -31,11 +23,19 @@ pub struct TypeDef {
     pub name: SymbolID,
     pub fields: Vec<TypeFieldDef>,
 }
-impl FromSyntax<syntax::TypeDef> for TypeDef {
+impl ISemanticAnalyze for TypeDef {
+
+    type SyntaxItem = syntax::TypeDef;
+
     fn from_syntax(node: syntax::TypeDef, parent_scope: SharedDefScope) -> TypeDef {
         TypeDef{
             name: node.name.value,
-            fields: node.fields.into_iter().map(|field| FromSyntax::from_syntax(field, parent_scope.clone())).collect(),
+            fields: node.fields.into_iter().map(|field| {
+                TypeFieldDef{
+                    name: field.name.value,
+                    typeuse: TypeUse::from_syntax(field.typeuse, parent_scope.clone()),
+                }
+            }).collect(),
         }
     }
 }

--- a/semantic/src/lib.rs
+++ b/semantic/src/lib.rs
@@ -55,6 +55,8 @@ pub use self::statement::ElseIfClause;
 pub use self::statement::ElseClause;
 pub use self::statement::IfStatement;
 pub use self::statement::Item;
+pub use self::statement::ImportStatement;
+pub use self::statement::UseStatement;
 pub use self::package::Package;
 
 use self::def_scope::DefScope;

--- a/semantic/src/lib.rs
+++ b/semantic/src/lib.rs
@@ -5,7 +5,8 @@
 ///!
 ///! semantic, semantic analyze
 
-/* #[cfg_attr(test, macro_use)] */ extern crate codemap;
+#[cfg(test)] #[macro_use] extern crate util;      // difference is util is referenced only in test
+#[cfg_attr(test, macro_use)] extern crate codemap;
 // #[macro_use] extern crate messages as message;
 // #[macro_use] extern crate util;
 extern crate lexical;

--- a/semantic/src/lib.rs
+++ b/semantic/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate lexical;
 extern crate syntax;
 
-mod traits;
+mod analyze_helper;
 mod expr;
 mod items;
 mod statement;
@@ -57,9 +57,8 @@ pub use self::statement::Item;
 pub use self::package::Package;
 
 use self::def_scope::DefScope;
-use self::def_scope::FromSyntax;
 use self::def_scope::SharedDefScope;
-use self::traits::ISemanticAnalyze;
+use self::analyze_helper::ISemanticAnalyze;
 
 #[cfg(test)] #[test]
 fn it_works() {

--- a/semantic/src/package.rs
+++ b/semantic/src/package.rs
@@ -23,10 +23,36 @@ pub struct Package {
 impl Package {
     
     pub fn new(tree: syntax::SyntaxTree) -> Package {
+
+        // Phase 1: direct map
         let global_scope = Rc::new(RefCell::new(DefScope::new(String::new()))); // yes 4 news
-        let modules = tree.modules.into_iter().map(|module| Module::from_syntax(module, global_scope.clone())).collect::<Vec<Module>>();
+        let import_maps = tree.import_maps;
+        let mut modules = tree.modules.into_iter().map(|module| Module::from_syntax(module, global_scope.clone())).collect::<Vec<Module>>();
+
+        // Phase 1 special: build up module dependence tree
+        let mut main_module = modules[0].move_out();
+        main_module.buildup_imports(&import_maps, &mut modules);
+
         Package{ global_scope, modules }
     }
+}
+
+#[cfg(test)] #[test]
+fn package_buildup_import_map() {
+    use codemap::SourceCode;
+    use codemap::Span;
+
+    let pacakge = Package::new(syntax::SyntaxTree::new_modules(vec![
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(0, "import a; import b;")), vec![
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 1, 1), syntax::SimpleName::new(make_id!(1), make_span!(2, 2)))),
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 3, 3), syntax::SimpleName::new(make_id!(2), make_span!(4, 4)))),
+        ]),
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(1, "")), vec![]),
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(2, "")), vec![]),
+    ], vec![
+        syntax::ImportMap::new(0, make_id!(1), 1),
+        syntax::ImportMap::new(0, make_id!(2), 2),
+    ]));
 }
 
 // TODO: add scope name, where global is package name, fn main is package name + "::main", fn main for stmt is package name + "::main::<for-stmt<5:5-10:5>>"

--- a/semantic/src/package.rs
+++ b/semantic/src/package.rs
@@ -17,14 +17,14 @@ use super::Module;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct Package {
-    modules: Vec<Module>,
+    main_module: Module,
     global_scope: SharedDefScope,
 }
 impl Package {
     
     pub fn new(tree: syntax::SyntaxTree) -> Package {
 
-        // Phase 1: direct map
+        // Phase 1: direct map, scope management
         let global_scope = Rc::new(RefCell::new(DefScope::new(String::new()))); // yes 4 news
         let import_maps = tree.import_maps;
         let mut modules = tree.modules.into_iter().map(|module| Module::from_syntax(module, global_scope.clone())).collect::<Vec<Module>>();
@@ -33,26 +33,82 @@ impl Package {
         let mut main_module = modules[0].move_out();
         main_module.buildup_imports(&import_maps, &mut modules);
 
-        Package{ global_scope, modules }
+        Package{ global_scope, main_module }
     }
+}
+
+#[cfg(test)] #[test]
+fn analyze_scope_manage() {
+    
 }
 
 #[cfg(test)] #[test]
 fn package_buildup_import_map() {
     use codemap::SourceCode;
     use codemap::Span;
+    use super::*;
 
-    let pacakge = Package::new(syntax::SyntaxTree::new_modules(vec![
+    let package = Package::new(syntax::SyntaxTree::new_modules(vec![
         syntax::Module::new(Rc::new(SourceCode::with_test_str(0, "import a; import b;")), vec![
-            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 1, 1), syntax::SimpleName::new(make_id!(1), make_span!(2, 2)))),
-            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 3, 3), syntax::SimpleName::new(make_id!(2), make_span!(4, 4)))),
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 1, 1), syntax::SimpleName::new(make_id!(1), make_span!(0, 2, 2)))),
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(0, 3, 3), syntax::SimpleName::new(make_id!(2), make_span!(0, 4, 4)))),
         ]),
-        syntax::Module::new(Rc::new(SourceCode::with_test_str(1, "")), vec![]),
-        syntax::Module::new(Rc::new(SourceCode::with_test_str(2, "")), vec![]),
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(1, "import c;")), vec![   // a
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(1, 1, 1), syntax::SimpleName::new(make_id!(3), make_span!(1, 2, 2)))),
+        ]),
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(2, "")), vec![]),         // b
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(3, "import d;")), vec![   // c
+            syntax::Item::Import(syntax::ImportStatement::new_default(make_span!(3, 1, 1), syntax::SimpleName::new(make_id!(4), make_span!(3, 2, 2)))),
+        ]),
+        syntax::Module::new(Rc::new(SourceCode::with_test_str(4, "")), vec![]),         // d
     ], vec![
         syntax::ImportMap::new(0, make_id!(1), 1),
         syntax::ImportMap::new(0, make_id!(2), 2),
+        syntax::ImportMap::new(1, make_id!(3), 3),
+        syntax::ImportMap::new(3, make_id!(4), 4),
     ]));
+
+    let expect = Module{
+        module_id: 0,
+        items: vec![
+            Item::Import(ImportStatement{
+                name: SimpleName{ value: make_id!(1) },
+                alias: None,
+                module: Some(Module{
+                    module_id: 1,
+                    items: vec![
+                        Item::Import(ImportStatement{
+                            name: SimpleName{ value: make_id!(3) },
+                            alias: None,
+                            module: Some(Module{
+                                module_id: 3,
+                                items: vec![
+                                    Item::Import(ImportStatement{
+                                        name: SimpleName{ value: make_id!(4) },
+                                        alias: None,
+                                        module: Some(Module{
+                                            module_id: 4,
+                                            items: vec![],
+                                        }),
+                                    }),
+                                ],
+                            }),
+                        }),
+                    ],
+                }),
+            }),
+            Item::Import(ImportStatement{
+                name: SimpleName{ value: make_id!(2) },
+                alias: None,
+                module: Some(Module{
+                    module_id: 2,
+                    items: vec![],
+                }),
+            }),
+        ],
+    };
+
+    assert_eq!(package.main_module, expect);
 }
 
 // TODO: add scope name, where global is package name, fn main is package name + "::main", fn main for stmt is package name + "::main::<for-stmt<5:5-10:5>>"

--- a/semantic/src/package.rs
+++ b/semantic/src/package.rs
@@ -9,7 +9,6 @@ use std::cell::RefCell;
 
 use syntax;
 
-use super::FromSyntax;
 use super::Statement;
 use super::ISemanticAnalyze;
 use super::DefScope;
@@ -18,19 +17,15 @@ use super::Module;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct Package {
-    main_module: Vec<Module>,
+    modules: Vec<Module>,
     global_scope: SharedDefScope,
 }
 impl Package {
     
-    pub fn from_syntax(root: syntax::SyntaxTree) -> Package {
+    pub fn new(tree: syntax::SyntaxTree) -> Package {
         let global_scope = Rc::new(RefCell::new(DefScope::new(String::new()))); // yes 4 news
-        let modules = root.modules.into_iter().map(|module| FromSyntax::from_syntax(module, global_scope.clone())).collect::<Vec<Module>>();
-        Package{ global_scope, main_module: modules }
-    }
-}
-impl ISemanticAnalyze for Package {
-    fn collect_type_declarations(&mut self) {
+        let modules = tree.modules.into_iter().map(|module| Module::from_syntax(module, global_scope.clone())).collect::<Vec<Module>>();
+        Package{ global_scope, modules }
     }
 }
 

--- a/semantic/src/statement/mod.rs
+++ b/semantic/src/statement/mod.rs
@@ -19,6 +19,7 @@ use super::Name;
 use super::SimpleName;
 use super::SharedDefScope;
 use super::ISemanticAnalyze;
+use super::Module;
 
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct BlockStatement {
@@ -269,6 +270,7 @@ impl ISemanticAnalyze for UseStatement {
 #[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub struct ImportStatement {
     pub name: SimpleName,
+    pub module: Option<Module>,
     pub alias: Option<SimpleName>,
 }
 impl ISemanticAnalyze for ImportStatement {
@@ -279,6 +281,7 @@ impl ISemanticAnalyze for ImportStatement {
         ImportStatement{
             name: SimpleName::from_syntax(node.name, parent_scope.clone()),
             alias: node.target.map(|target| SimpleName::from_syntax(target, parent_scope)),
+            module: None,
         }
     }
 }

--- a/semantic/src/traits.rs
+++ b/semantic/src/traits.rs
@@ -1,8 +1,0 @@
-///! fff-lang
-///!
-///! semantic/traits
-
-pub trait ISemanticAnalyze {
-
-    fn collect_type_declarations(&mut self);
-}

--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -67,8 +67,8 @@ use self::parse_sess::ParseResult;
 use self::parse_sess::ISyntaxGrammar;
 pub use self::parse_sess::ISyntaxParse;
 
-use self::format_helper::Formatter;
-use self::format_helper::ISyntaxFormat;
+pub use self::format_helper::Formatter;
+pub use self::format_helper::ISyntaxFormat;
 pub use self::test_helper::TestInput;
 pub use self::test_helper::WithTestInput;
 


### PR DESCRIPTION
- Check invalid import in syntax, which also prevents circle imports
- Merge `FromSyntax` into `ISemanticAnalyze` and add new trait methods
- Copy syntax's format infrastructure into semantic